### PR TITLE
Stop timer on disable and run commands async

### DIFF
--- a/netctl-auto-gnome@nigelmichki.ninja/extension.js
+++ b/netctl-auto-gnome@nigelmichki.ninja/extension.js
@@ -149,25 +149,33 @@ const NetctlSwitcher = new Lang.Class({
 
    _refresh_details: function() {
       event = GLib.timeout_add_seconds(0, REFRESH_TIME, Lang.bind(this, function () {
-         this._set_icon();
-         this._update_menu();
-         return true;
+         if(enabled){
+            this._set_icon();
+            this._update_menu();
+            return true;
+         }
+         else {
+            return false;
+         }
       }));
    }
 
 });
 
 let netctlSwitcher;
+let enabled = false;
 
 function init() {
 }
 
 function enable() {
+   enabled = true
    netctlSwitcher = new NetctlSwitcher();
    Main.panel.addToStatusArea('NetctlSwitcher', netctlSwitcher);
 }
 
 function disable() {
    netctlSwitcher.destroy();
+   enabled = false;
 }
 


### PR DESCRIPTION
Thanks for maintaining this extension :heart:

I noticed that after enabling netctl-auto-gnome, gnome would freeze briefly on regular intervals and this would continue after disabling the extension.

This commit fixes those issues by adding some logic to stop the timeout after the extension is disabled and also using [`Gio.Subprocess`](https://wiki.gnome.org/AndyHolmes/Sandbox/SpawningProcesses) with javascript async/await instead of `GLib.spawn_command_line_sync` and `GLib.spawn_async`.